### PR TITLE
Fix parameter mismatch in Filesystem when using Composer >=2.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
   },
   "require": {
     "php": "^7.3 || ^8.0",
-    "composer-plugin-api": "^1.1 || ^2.0",
+    "composer": ">=2.3.0",
+    "composer-plugin-api": ">=2.2.0",
     "naucon/file": "^1.0",
     "symfony/filesystem": "^5.0",
     "webmozart/glob": "^4.3"

--- a/src/File/FileSystemInterface.php
+++ b/src/File/FileSystemInterface.php
@@ -38,7 +38,7 @@ interface FileSystemInterface
      * @param string $targetFile The target filename
      * @return bool
      */
-    public function copy($originFile, $targetFile): bool ;
+    public function copy(string $originFile, string $targetFile): bool ;
 
     /**
      * Creates a directory recursively.
@@ -72,11 +72,11 @@ interface FileSystemInterface
     /**
      * Removes files or directories.
      *
-     * @param string|iterable $files A filename, an array of files, or a \Traversable instance to remove
+     * @param string $file A filename or directory to remove
      *
      * @throws IOException When removal fails
      */
-    public function remove($files);
+    public function remove(string $file);
 
     /**
      * Change mode for an array of files or directories.
@@ -117,9 +117,9 @@ interface FileSystemInterface
      *
      * @param string $origin The origin filename or directory
      * @param string $target The new filename or directory
-     * @return
+     * @return void
      */
-    public function rename($origin, $target);
+    public function rename(string $origin, string $target);
 
     /**
      * Creates a symbolic link or copy a directory.
@@ -168,5 +168,5 @@ interface FileSystemInterface
      *
      * @return bool
      */
-    public function isAbsolutePath($file);
+    public function isAbsolutePath(string $file);
 }


### PR DESCRIPTION
Parameter types in `CPSIT\SetupHelper\File\FileSystemInterface` method parameters added to match those in `Composer\Util\Filesystem`, since it caused a mismatch in `CPSIT\SetupHelper\File\FileSystem` which extended / implemented both.

This was introduced here: https://github.com/composer/composer/blob/6da38f83a0d5acc71793f337b525fa2faff9468e/src/Composer/Util/Filesystem.php

This change probably breaks compatibility to Composer < 2.3.0